### PR TITLE
feat: requirements.txt + readme markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Before you can run the application, make sure you have the following dependencie
 - Flask (Python web framework)
 - prettytable (for displaying results in tabular format)
 
-You can install Flask and prettytable using pip:
+You can install these and more with:
 
 ```bash
-pip install Flask prettytable
+$ pip install -r requirements.txt
+```
 
 Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+blinker==1.6.3
+click==8.1.7
+Flask==3.0.0
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+numpy==1.26.1
+pandas==2.1.1
+prettytable==3.9.0
+python-dateutil==2.8.2
+pytz==2023.3.post1
+six==1.16.0
+tzdata==2023.3
+wcwidth==0.2.8
+Werkzeug==3.0.1


### PR DESCRIPTION
Using a `requirements.txt` file can get users of your application up to speed quickly without having to install packages individually. You can also control which versions are installed for cases where two dependency versions are not compatible.